### PR TITLE
ZCS-8017: updating guava version to 28.1-jre from 23.0 and centrally

### DIFF
--- a/ivy.xml
+++ b/ivy.xml
@@ -7,7 +7,7 @@
  <dependencies>
   <dependency org="junit" name="junit" rev="4.8.2" />
   <dependency org="log4j" name="log4j" rev="1.2.16" />
-  <dependency org="com.google.guava" name="guava" rev="23.0" />
+  <dependency org="com.google.guava" name="guava" rev="${com.google.guava.version}" />
   <dependency org="commons-fileupload" name="commons-fileupload" rev="1.4"/>
   <dependency org="commons-logging" name="commons-logging" rev="1.1.1"/>
   <dependency org="zimbra" name="zm-common" rev="latest.integration" />


### PR DESCRIPTION
Issue:
Vulnerabilities in older version 23.0 of Guava.

Fix:
Update version to 28.1-jre and make it available centrally